### PR TITLE
README.md: update references to wait function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ bot.on('message', async message => {
 
 ### Send Responses
 ```es6
-import {Elements} from 'facebook-messenger-bot'; // import Bot class
+import {Bot, Elements} from 'facebook-messenger-bot'; // import Bot class
 
 bot.on('message', async message => {
     const {sender} = message;
@@ -129,14 +129,14 @@ bot.on('message', async message => {
     await bot.send(sender.id, out);
 
     // wait for 1s
-    await bot.wait(1000);
+    await Bot.wait(1000);
 
     // ---- send image
     const out = new Elements();
     out.add({image: 'https://developers.facebook.com/images/devsite/fb4d_logo-2x.png'});
     await bot.send(sender.id, out);
 
-    await bot.wait(1000);
+    await Bot.wait(1000);
 
     // ---- send buttons (single card)
     buttons = new Buttons();
@@ -155,7 +155,7 @@ bot.on('message', async message => {
     out.add({text: 'ABC Flower shop', subtext: 'Office hours 10am - 6pm', buttons}); // add a card
     await bot.send(to, out);
 
-    await bot.wait(2000);
+    await Bot.wait(2000);
 
   	// ---- send list
   	out = new Elements();
@@ -204,7 +204,7 @@ bot.on('message', async message => {
     out = new Elements();
     out.add({image: 'http://someimage.com', text: 'hey', buttons});
     await bot.send(to, out);
-    await sleep(2000);
+    await Bot.wait(2000);
 });
 
 bot.on('search-engine', async (data, message) => {


### PR DESCRIPTION
In your documentation, there are references to both bot.wait() and sleep(), but neither functions are available from FacebookMessengerBot. The function is Bot.wait(). I replaced all instances of bot.wait() and sleep() with Bot.wait() in the readme :)