### PR TITLE
Add a fallback for when payload is parsable but empty. fix #16

### DIFF
--- a/src/Bot.js
+++ b/src/Bot.js
@@ -218,7 +218,7 @@ class Bot extends EventEmitter {
       let postback = {};
 
       try {
-        postback = JSON.parse(message.quick_reply.payload);
+        postback = JSON.parse(message.quick_reply.payload) || {};
       } catch (e) {
         // ignore
       }


### PR DESCRIPTION
Prevent unhandled exception for quickreplies: https://github.com/bluejamesbond/FacebookMessengerBot.js/issues/16